### PR TITLE
Support sphinx refs for project local links

### DIFF
--- a/ox-rst.el
+++ b/ox-rst.el
@@ -98,6 +98,7 @@
     (:rst-link-home "RST_LINK_HOME" nil org-rst-link-home)
     (:rst-link-use-ref-role nil nil org-rst-link-use-ref-role)
     (:rst-extension nil nil org-rst-extension)
+    (:rst-file-link-use-ref-role nil nil org-rst-file-link-use-ref-role)
     (:rst-text-markup-alist nil nil org-rst-text-markup-alist)
     (:rst-quote-margin nil nil org-rst-quote-margin)
     (:rst-headline-underline-characters nil nil org-rst-headline-underline-characters)
@@ -182,6 +183,11 @@ link's path."
 
 (defcustom org-rst-link-use-ref-role nil
   "Non-nil means export internal links using :ref: role."
+  :group 'org-export-rst
+  :type 'boolean)
+
+(defcustom org-rst-file-link-use-ref-role nil
+  "Non-nil means export internal file links using :ref: role."
   :group 'org-export-rst
   :type 'boolean)
 
@@ -947,6 +953,7 @@ INFO is a plist holding contextual information."
 					   (plist-get info :rst-extension)))
 			  (t raw-path)))))
 		 (type (org-element-property :type link))
+		 (search-option (org-element-property :search-option link))
 		 (raw-path (org-element-property :path link))
 		 ;; Ensure DESC really exists, or set it to nil.
 		 (desc (and (not (string= desc "")) desc))
@@ -1050,6 +1057,13 @@ INFO is a plist holding contextual information."
      ((string= type "coderef")
       (format (org-export-get-coderef-format path desc)
 			  (org-export-resolve-coderef path info)))
+     ((and (plist-get info :rst-file-link-use-ref-role)
+           (string= type "file")
+           search-option)
+      (let ((ref (replace-regexp-in-string "^#" "" search-option)))
+        (if desc
+            (format ":ref:`%s <%s>`" desc ref)
+          (format ":ref:`%s`" ref))))
      ;; Link type is handled by a special function.
      ;((functionp (setq protocol (nth 2 (assoc type org-link-protocols))))
      ; (funcall protocol (org-link-unescape path) desc 'latex))


### PR DESCRIPTION
Sphinx is using refs to project internal targets in other files. This patch convert org mode file links to such refs. Enabled via setting.

I don't know how much sphinx specific constructs you support, iow how willing you are to accept patches like this.
This seems to be the single most important missing feature in this package for using org mode to write docs for readthedocs.io though.

This patch could probably be improved a bit if you think it's a good idea to include it.
For instance, this might not need a separate setting but could be merged into `org-rst-link-use-ref-role` possibly. Might also want some sanity checks on the file links to make sure the file is reachable from the project.